### PR TITLE
remappings: Adds deeper remappings links to fix coverage

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -3,5 +3,8 @@ forge-std/=lib/forge-std/src/
 
 chronicle-std/=lib/chronicle-std/src/
 @script/chronicle-std/=lib/chronicle-std/script/
+lib/chronicle-std:src/=lib/chronicle-std/src/
+lib/chronicle-std:ds-test/=lib/chronicle-std/lib/forge-std/lib/ds-test/src/
+lib/chronicle-std:forge-std/=lib/chronicle-std/lib/forge-std/src/
 
 greenhouse/=lib/greenhouse/src/


### PR DESCRIPTION
`forge coverage` command was broken since the `@script/` remappings got added because the deeper imports weren't correctly remapped.

Verify via `forge coverage --ir-minimum`. Once #13 merged will also be possible again without using `--via-ir`.