### PR TITLE
[draft] Missing Px mod N

### DIFF
--- a/src/libs/LibSchnorr.sol
+++ b/src/libs/LibSchnorr.sol
@@ -78,7 +78,7 @@ library LibSchnorr {
             v = pubKey.yParity() + 27;
         }
 
-        // Set r = Pₓ
+        // Set r = Pₓ % Q
         uint r = pubKey.x % LibSecp256k1.Q();
 
         // Compute s = Q - (e * Pₓ) (mod Q)

--- a/src/libs/LibSchnorr.sol
+++ b/src/libs/LibSchnorr.sol
@@ -79,7 +79,7 @@ library LibSchnorr {
         }
 
         // Set r = Pₓ
-        uint r = pubKey.x;
+        uint r = pubKey.x % LibSecp256k1.Q();
 
         // Compute s = Q - (e * Pₓ) (mod Q)
         //


### PR DESCRIPTION
See https://github.com/chronicleprotocol/scribe/issues/56

Not entirely sure if this is the correct interpretation but the ecdsa spec r is required to be less than the order of the curve: 
See: https://github.com/ethereum/go-ethereum/blob/master/crypto/crypto.go#L271

However, I believe keys with an x coordinate greater than Q just require a mod Q in order to be valid???
Page 4: https://www.cs.miami.edu/home/burt/learning/Csc609.142/ecdsa-cert.pdf definition of r is P.x % Q