### PR TITLE
chore: fix incorrect use of `--sig` with pre-encoded calldata

### DIFF
--- a/script/benchmarks/relay.sh
+++ b/script/benchmarks/relay.sh
@@ -22,7 +22,7 @@ run_Scribe () {
     # Deploy Scribe
     forge script script/benchmarks/ScribeBenchmark.s.sol --rpc-url http://127.0.0.1:8545 --broadcast --sig "deploy()" > /dev/null 2>&1
     # Set bar
-    forge script script/benchmarks/ScribeBenchmark.s.sol --rpc-url http://127.0.0.1:8545 --broadcast --sig $(cast calldata "setBar(uint8)" $bar) > /dev/null 2>&1
+    forge script script/benchmarks/ScribeBenchmark.s.sol --rpc-url http://127.0.0.1:8545 --broadcast --sig "setBar(uint8)" --args $bar > /dev/null 2>&1
     # Lift feeds
     forge script script/benchmarks/ScribeBenchmark.s.sol --rpc-url http://127.0.0.1:8545 --broadcast --sig "liftFeeds()" > /dev/null 2>&1
     # Poke once


### PR DESCRIPTION
### description of pull request:

While reviewing the benchmarking script, I noticed an issue where `--sig` was being used with `cast calldata`, which is incorrect. The `--sig` flag expects a function signature with arguments, not pre-encoded calldata.  

This has been fixed by replacing:  
```bash
--sig $(cast calldata "setBar(uint8)" $bar)
```
with  
```bash
--sig "setBar(uint8)" --args $bar
```  

Now the script correctly passes arguments to `forge script`. 